### PR TITLE
Fix the Twitter rename breaking macro wrapping

### DIFF
--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -52,7 +52,7 @@
     (boolean (text-util/get-matched-video url))
     (util/format "{{video %s}}" url)
 
-    (string/includes? url "twitter.com")
+    (or (string/includes? url "twitter.com") (string/includes? url "x.com"))
     (util/format "{{twitter %s}}" url)))
 
 (defn- try-parse-as-json

--- a/src/main/frontend/quick_capture.cljs
+++ b/src/main/frontend/quick_capture.cljs
@@ -14,7 +14,8 @@
 (defn- is-tweet-link
   [url]
   (when (not-empty url)
-    (re-matches #"^https://twitter\.com/.*?/status/.*?$" url)))
+    (or (re-matches #"^https://twitter\.com/.*?/status/.*?$" url)
+        (re-matches #"^https://x\.com/.*?/status/.*?$" url))))
 
 (defn quick-capture [args]
   (let [{:keys [url title content page append]} (bean/->clj args)

--- a/src/test/frontend/handler/paste_test.cljs
+++ b/src/test/frontend/handler/paste_test.cljs
@@ -122,6 +122,22 @@
           (is (= expected-paste result))
           (reset))))))
 
+(deftest-async editor-on-paste-with-twitter-is-now-x-lol
+  (testing "Formatted paste for the site formerly known as twitter link should paste macro wrapped as twitter"
+    (let [clipboard "https://x.com/chiefnoah13/status/1792677792506843462"
+          expected-paste "{{twitter https://x.com/chiefnoah13/status/1792677792506843462}}"]
+      (test-helper/with-reset
+        reset
+        [commands/delete-selection! (constantly nil)
+         commands/simple-insert! (fn [_input text] (p/resolved text))
+         util/stop (constantly nil)
+         util/get-selected-text (constantly "")
+         html-parser/convert (constantly nil)]
+        (p/let [result ((paste-handler/editor-on-paste! nil)
+                        #js {:clipboardData #js {:getData (constantly clipboard)}})]
+          (is (= expected-paste result))
+          (reset))))))
+
 (deftest-async editor-on-paste-with-text-over-link
   (testing "Paste text over a selected formatted link"
     (let [actual-text (atom nil)


### PR DESCRIPTION
- **FIX twitter's rename causing automatic macro wrapping to not work**
- **ADD test to check for x => twitter macro expansion**

Fixes #11319

<!--
Thank you for the pull request. Please provide a description. Screenshots and gifs are appreciated for UX enhancements, new features and bug fixes!

For bug fixes and new features, please include tests and possibly benchmarks.
-->
